### PR TITLE
Add subsection support to sidebar

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -183,7 +183,7 @@ h6 {
 	--text-xs: 0.75rem;
 	--text-sm: 0.875rem;
 	--text-default: 1rem;
-	--text-lg:: 1.125rem;
+	--text-lg: 1.125rem;
 	--text-xl: 1.25rem;
 	--text-2xl: 1.5rem;
 	--text-3xl: 2.25rem;

--- a/src/components/LeftSidebar.astro
+++ b/src/components/LeftSidebar.astro
@@ -1,32 +1,35 @@
 ---
-import { sidebar } from "../sidebar";
+import { getSidebarEntries } from "../sidebar";
 
 interface Props {
   currentPage: string;
 }
 
 const { currentPage } = Astro.props;
+const sidebar = getSidebarEntries();
 ---
 
 <nav aria-label="Primary">
   {
-    Object.entries(sidebar).map(([header, children]) => (
+    sidebar.map(({ header, depth, children }) => (
       <>
-        <h2 class="divider">{header}</h2>
-        <ul>
-          {children.map(({ slug, text }) => {
-            return (
-              <li>
-                <a
-                  href={`${Astro.site?.pathname}${slug}/`}
-                  aria-current={currentPage.includes(slug) ? "page" : false}
-                >
-                  {text}
-                </a>
-              </li>
-            );
-          })}
-        </ul>
+        {depth == 1 ? <h2 class="divider">{header}</h2> : <h3>{header}</h3>}
+        {children !== null && (
+          <ul>
+            {children.map(({ slug, text }) => {
+              return (
+                <li data-depth={depth}>
+                  <a
+                    href={`${Astro.site?.pathname}${slug}/`}
+                    aria-current={currentPage.includes(slug) ? "page" : false}
+                  >
+                    {text}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        )}
       </>
     ))
   }
@@ -48,6 +51,12 @@ const { currentPage } = Astro.props;
     padding-bottom: var(--spacing-2);
   }
 
+  nav h3 {
+    color: var(--text-secondary);
+    font-size: var(--text-lg);
+    font-weight: 700;
+  }
+
   nav ul {
     padding: 0;
     margin-bottom: var(--spacing-8);
@@ -61,17 +70,26 @@ const { currentPage } = Astro.props;
   li a {
     color: var(--text-secondary);
     text-decoration: none;
+  }
+
+  li[data-depth="1"] a {
     font-weight: 600;
+  }
+
+  li[data-depth="2"] a {
+    font-size: var(--text-sm);
+    margin-left: var(--spacing-6);
   }
 
   li a[aria-current="page"] {
     color: var(--solid-blue);
   }
 
-  nav h2:hover, li a:hover {
+  nav h2:hover,
+  li a:hover {
     color: var(--gray-4);
     transition: color;
-    transition-timing-function: cubic-bezier(.4,0,.2,1);
-    transition-duration: .15s;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 0.15s;
   }
 </style>

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,7 +1,54 @@
-type Sidebar = Record<string, { text: string; slug: string }[]>;
+type SidebarEntry = { text: string; slug: string };
+type Sidebar = Record<string, SidebarEntry[] | Record<string, SidebarEntry[]>>;
+
+type GeneratedSidebar = {
+  header: string;
+  depth: number;
+  children: SidebarEntry[] | null;
+}[];
 
 export const sidebar: Sidebar = {
-	"Start Here": [],
-	Tutorials: [],
-	Concepts: [],
+  "Getting Started": [
+    { text: "What is Solid?", slug: "getting-started/what-is-solid" },
+  ],
+  "Core Concepts": [
+    { text: "Head and metadata", slug: "core-concepts/head-metadata" },
+  ],
+  "API Reference": {
+    Router: [
+      { text: "A", slug: "api/a" },
+      { text: "B", slug: "api/b" },
+    ],
+  },
 };
+
+// Converts the sidebar object into a easier format for component-usage.
+export function getSidebarEntries() {
+  const entries: GeneratedSidebar = [];
+
+  Object.entries(sidebar).map(([header, items]) => {
+    if (Array.isArray(items)) {
+      entries.push({
+        header: header,
+        depth: 1,
+        children: items,
+      });
+    } else {
+      entries.push({
+        header: header,
+        depth: 1,
+        children: null,
+      });
+
+      Object.entries(items).map(([header, entry]) => {
+        entries.push({
+          header: header,
+          depth: 2,
+          children: entry,
+        });
+      });
+    }
+  });
+
+  return entries;
+}


### PR DESCRIPTION
This PR adds support for sidebar sections composed of subsections, for sections like API References as an example.

![image](https://user-images.githubusercontent.com/61414485/230926608-dd360b7b-6118-4812-bfac-a7d27894e92e.png)
