### PR TITLE
Add mobile sidebar and improve CLS & a11y

### DIFF
--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -1,11 +1,15 @@
 ---
 import ThemeToggle from "./ThemeToggle";
+import MobileNavToggle from "./MobileNavToggle";
 import Logo from "./Logo.astro";
 ---
 
 <header>
   <Logo />
-  <ThemeToggle client:load />
+  <div class="right-container">
+    <ThemeToggle client:load />
+    <MobileNavToggle client:media="(max-width: 50em)" />
+  </div>
 </header>
 
 <style>
@@ -15,14 +19,21 @@ import Logo from "./Logo.astro";
 
   header {
     position: fixed;
-    padding-left: 1.5rem;
-    padding-right: 0.5rem;
+    padding-inline: var(--spacing-7);
     display: flex;
     justify-content: space-between;
+    align-items: center;
     background-color: var(--bg-base);
     width: 100%;
     height: var(--header-height);
     box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
     z-index: 999;
+  }
+
+  .right-container {
+    display: flex;
+    gap: var(--spacing-1);
+    flex-direction: row;
+    align-items: center;
   }
 </style>

--- a/src/components/Header/Logo.astro
+++ b/src/components/Header/Logo.astro
@@ -1,9 +1,16 @@
 <div class="logo-container">
-  <img class="icon" aria-hidden="true" src="/logos/solid-icon.svg" />
+  <img
+    width="36px"
+    height="36px"
+    aria-hidden="true"
+    src="/logos/solid-icon.svg"
+  />
   <!-- Same SVG as public/logos/solid-logo.svg, needs to be used locally to react to CSS variables -->
   <svg
     aria-hidden="true"
     class="name"
+    height="42px"
+    width="185px"
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     height="70.7"
@@ -50,11 +57,13 @@
     align-items: center;
   }
 
-  .icon {
-    height: 36px;
+  .name {
+    display: none;
   }
 
-  .name {
-    height: 42px;
+  @media (min-width: 50em) {
+    .name {
+      display: block;
+    }
   }
 </style>

--- a/src/components/Header/MobileNavToggle.module.css
+++ b/src/components/Header/MobileNavToggle.module.css
@@ -1,0 +1,22 @@
+.button {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.button svg {
+  color: var(--text-base);
+}
+
+:global(.mobile-menu) .button {
+  border-color: var(--text-base);
+  border-radius: var(--spacing-1);
+}
+
+@media (max-width: 50em) {
+  .button {
+    display: inline;
+  }
+}

--- a/src/components/Header/MobileNavToggle.tsx
+++ b/src/components/Header/MobileNavToggle.tsx
@@ -1,0 +1,33 @@
+import { Component, createEffect, createSignal } from "solid-js";
+import IconHamburger from "~icons/heroicons-solid/bars-3";
+import { ToggleButton } from "@kobalte/core";
+import styles from "./MobileNavToggle.module.css";
+
+const MobileNavToggle: Component = () => {
+  const [isOpen, setIsOpen] = createSignal<boolean>(false);
+
+  createEffect(() => {
+    if (isOpen()) {
+      document.body.classList.add("mobile-menu");
+    } else {
+      document.body.classList.remove("mobile-menu");
+    }
+  });
+
+  function toggleMenu() {
+    setIsOpen(!isOpen());
+  }
+
+  return (
+    <ToggleButton.Root
+      isPressed={isOpen()}
+      onPressedChange={toggleMenu}
+      class={styles.button}
+      aria-label="Open mobile menu"
+    >
+      <IconHamburger width="24" height="24" aria-hidden="true" />
+    </ToggleButton.Root>
+  );
+};
+
+export default MobileNavToggle;

--- a/src/components/Header/ThemeToggle.module.css
+++ b/src/components/Header/ThemeToggle.module.css
@@ -5,7 +5,5 @@
 }
 
 .button svg {
-  width: 38px;
-  height: 38px;
   color: var(--text-base);
 }

--- a/src/components/Header/ThemeToggle.tsx
+++ b/src/components/Header/ThemeToggle.tsx
@@ -1,6 +1,6 @@
 import { Component, createEffect, createSignal, onMount } from "solid-js";
-import CarbonSun from "~icons/carbon/sun";
-import CarbonMoon from "~icons/carbon/moon";
+import IconSun from "~icons/heroicons-solid/sun";
+import IconMoon from "~icons/heroicons-solid/moon";
 import { ToggleButton } from "@kobalte/core";
 import styles from "./ThemeToggle.module.css";
 
@@ -29,9 +29,15 @@ const ThemeToggle: Component = () => {
       isPressed={isDark()}
       onPressedChange={toggleTheme}
       class={styles.button}
-      aria-label="Mute"
+      aria-label="Use dark theme"
     >
-      {(state) => (state.isPressed() ? <CarbonMoon /> : <CarbonSun />)}
+      {(state) =>
+        state.isPressed() ? (
+          <IconMoon width="24px" height="24px" aria-hidden="true" />
+        ) : (
+          <IconSun width="24px" height="24px" aria-hidden="true" />
+        )
+      }
     </ToggleButton.Root>
   );
 };

--- a/src/components/LeftSidebar.astro
+++ b/src/components/LeftSidebar.astro
@@ -28,7 +28,7 @@ function routeIncludesChild(children: SidebarEntry[]) {
           <h2>{header}</h2>
         ) : (
           <h3>
-            <a href={"/" + children[0]?.slug}>{header}</a>
+            <a href={"/" + children[0]?.slug + "/"}>{header}</a>
           </h3>
         )}
         {children.length && (depth === 1 || routeIncludesChild(children)) ? (
@@ -62,20 +62,19 @@ function routeIncludesChild(children: SidebarEntry[]) {
     scrollbar-gutter: stable;
   }
 
-  nav h2 {
+  h2 {
     color: var(--text-base);
     font-size: var(--text-xl);
     font-weight: 400;
     padding-bottom: var(--spacing-2);
   }
 
-  nav h3 {
-    color: var(--text-secondary);
-    font-size: var(--text-lg);
-    font-weight: 700;
+  h3 {
+    font-size: var(--text-default);
+    font-weight: 600;
   }
 
-  nav ul {
+  ul {
     padding: 0;
     margin-bottom: var(--spacing-8);
     list-style-type: none;
@@ -85,13 +84,9 @@ function routeIncludesChild(children: SidebarEntry[]) {
     margin-top: var(--spacing-8);
   }
 
-  nav li {
+  li,
+  h3 {
     padding-block: var(--spacing-1);
-  }
-
-  a {
-    color: var(--text-secondary);
-    text-decoration: none;
   }
 
   li[data-depth="1"] a {
@@ -103,16 +98,29 @@ function routeIncludesChild(children: SidebarEntry[]) {
     margin-left: var(--spacing-6);
   }
 
+  a {
+    color: var(--text-secondary);
+    text-decoration: none;
+  }
+
   a[aria-current="page"] {
     color: var(--solid-blue);
   }
 
-  nav h2,
-  li a {
+  h2,
+  h3,
+  a {
     transition: color 0.15s ease;
   }
 
   a:hover {
     color: var(--gray-4);
+  }
+
+  @media (max-width: 50em) {
+    a {
+      display: flex;
+      width: 100%;
+    }
   }
 </style>

--- a/src/components/Preferences/Preferences.tsx
+++ b/src/components/Preferences/Preferences.tsx
@@ -50,7 +50,7 @@ const Preferences: Component = () => {
       <summary>
         <div class={styles.summaryContainer}>
           <div class={styles.iconBackground}>
-            <IconGear aria-hidden />
+            <IconGear height="20px" width="20px" aria-hidden="true" />
           </div>
           Preferences
         </div>
@@ -71,7 +71,7 @@ const Preferences: Component = () => {
             >
               <RadioGroup.ItemInput />
               <RadioGroup.ItemControl>
-                <IconJs />
+                <IconJs aria-hidden="true" />
                 {/* <RadioGroup.ItemIndicator /> */}
               </RadioGroup.ItemControl>
               <RadioGroup.ItemLabel>JavaScript</RadioGroup.ItemLabel>
@@ -82,7 +82,7 @@ const Preferences: Component = () => {
             >
               <RadioGroup.ItemInput />
               <RadioGroup.ItemControl>
-                <IconTs />
+                <IconTs aria-hidden="true" />
                 {/* <RadioGroup.ItemIndicator /> */}
               </RadioGroup.ItemControl>
               <RadioGroup.ItemLabel>TypeScript</RadioGroup.ItemLabel>
@@ -105,7 +105,7 @@ const Preferences: Component = () => {
                 >
                   <RadioGroup.ItemInput />
                   <RadioGroup.ItemControl>
-                    <Dynamic component={icons[value]} />
+                    <Dynamic component={icons[value]} aria-hidden="true" />
                     {/* <RadioGroup.ItemIndicator /> */}
                   </RadioGroup.ItemControl>
                   <RadioGroup.ItemLabel>{value}</RadioGroup.ItemLabel>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -99,7 +99,7 @@ const currentPage = Astro.url.pathname;
     max-width: 60ch;
     margin-inline: auto;
     padding-block: var(--spacing-4);
-    padding-inline: var(--spacing-10);
+    padding-inline: var(--spacing-7);
   }
 
   aside {
@@ -111,7 +111,13 @@ const currentPage = Astro.url.pathname;
 
   .left-side {
     visibility: hidden;
-    width: var(--left-sidebar-width);
+  }
+
+  body.mobile-menu .left-side {
+    visibility: visible;
+    display: block;
+    inset-inline-end: 0;
+    width: 100%;
   }
 
   .right-side {
@@ -137,6 +143,7 @@ const currentPage = Astro.url.pathname;
 
     .left-side {
       visibility: visible;
+      width: var(--left-sidebar-width);
     }
   }
 </style>


### PR DESCRIPTION
- Improved sidebar styling to accommodate for smaller screens & ensure h3 and h2 have the same styles.
- Added mobile navigation sidebar.
- Changed ThemeToggle icons so that by default we use Heroicons.
- Inlined svg/image width and height to avoid CLS before CSS load.
- Added proper `aria-label` and `aria-hidden` to toggle components and icons.